### PR TITLE
feat(metrics): add Prometheus metrics endpoint

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,7 @@
         "express-slow-down": "^3.0.1",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.3",
+        "prom-client": "^15.1.3",
         "socket.io": "^4.8.3",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
@@ -101,6 +102,15 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/@prisma/client": {
       "version": "5.22.0",
@@ -337,6 +347,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -1734,6 +1750,19 @@
         "fsevents": "2.3.3"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2230,6 +2259,15 @@
       },
       "peerDependencies": {
         "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/text-hex": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "express-slow-down": "^3.0.1",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.3",
+    "prom-client": "^15.1.3",
     "socket.io": "^4.8.3",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -15,6 +15,8 @@ import { globalLimiter } from "./middlewares/rateLimiter.js";
 import healthRoutes from "./modules/health/health.routes.js";
 import swaggerUi from "swagger-ui-express";
 import swaggerSpec from "./config/swagger.js";
+import metricsRoutes from "./modules/metrics/metrics.routes.js";
+import { metricsMiddleware } from "./middlewares/metrics.middleware.js";
 
 import "./config/env.validation.js";
 
@@ -39,6 +41,8 @@ app.use("/api/friends", friendRoutes);
 app.use("/api/sessions", sessionRoutes);
 app.use("/api/health", healthRoutes);
 app.use("/api/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+app.use("/api/metrics", metricsRoutes);
+app.use(metricsMiddleware);
 
 // ======================
 // Health Check

--- a/backend/src/config/metrics.js
+++ b/backend/src/config/metrics.js
@@ -1,0 +1,18 @@
+import client from "prom-client";
+
+const register = new client.Registry();
+
+client.collectDefaultMetrics({
+  register,
+});
+
+export const httpRequestDuration = new client.Histogram({
+  name: "http_request_duration_seconds",
+  help: "Duration of HTTP requests in seconds",
+  labelNames: ["method", "route", "status"],
+  buckets: [0.1, 0.3, 0.5, 1, 2, 5],
+});
+
+register.registerMetric(httpRequestDuration);
+
+export { register };

--- a/backend/src/middlewares/metrics.middleware.js
+++ b/backend/src/middlewares/metrics.middleware.js
@@ -1,0 +1,21 @@
+import { httpRequestDuration } from "../config/metrics.js";
+
+export const metricsMiddleware = (req, res, next) => {
+  const start = process.hrtime();
+
+  res.on("finish", () => {
+    const diff = process.hrtime(start);
+    const duration = diff[0] + diff[1] / 1e9;
+
+    httpRequestDuration.observe(
+      {
+        method: req.method,
+        route: req.route?.path || req.path,
+        status: res.statusCode,
+      },
+      duration
+    );
+  });
+
+  next();
+};

--- a/backend/src/modules/metrics/metrics.routes.js
+++ b/backend/src/modules/metrics/metrics.routes.js
@@ -1,0 +1,11 @@
+import express from "express";
+import { register } from "../../config/metrics.js";
+
+const router = express.Router();
+
+router.get("/", async (req, res) => {
+  res.set("Content-Type", register.contentType);
+  res.end(await register.metrics());
+});
+
+export default router;


### PR DESCRIPTION
Closes #33 

## Summary
Introduce Prometheus-based metrics collection for the backend.

## Changes
- Integrated `prom-client` for metrics collection
- Added HTTP request duration histogram
- Enabled default Node.js process metrics
- Implemented metrics middleware to track request latency
- Exposed metrics endpoint at `/metrics`

## Purpose
This enables runtime monitoring of the backend, including request rates, latency, and system-level metrics. The endpoint is compatible with Prometheus scraping and improves observability of the application.